### PR TITLE
Handle multi page

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ https://url-to-the-tool/1234?epic=XX-11
 - [ ] Add an env variable to map custom jira fields to usable names
 - [ ] Add husky with lint-stage to enforce linting
 - [ ] Add time mark to logs
+- [ ] Include spec name in task description
 - [ ] Add item logs to the task description
 - [ ] Reduce calls to Jira API by keeping a cache of issues queried
 

--- a/src/requests/report-portal.ts
+++ b/src/requests/report-portal.ts
@@ -51,9 +51,9 @@ export const getLaunchById = (launchId: number) => {
   );
 };
 
-export const getLaunchFailedItems = (launchId: number) => {
+export const getLaunchFailedItems = (launchId: number, page = 1) => {
   const url = `${ENV.reportPortalApiUrl}/${ENV.reportPortalProject}/item`;
-  const query = `filter.eq.launchId=${launchId}&filter.eq.status=FAILED&page.size=100&filter.eq.type=STEP`;
+  const query = `filter.eq.launchId=${launchId}&filter.eq.status=FAILED&page.size=100&filter.eq.type=STEP&page.page=${page}`;
   return fetch(`${url}?${query}`, {
     method: "GET",
     headers,

--- a/src/requests/report-portal.ts
+++ b/src/requests/report-portal.ts
@@ -53,7 +53,7 @@ export const getLaunchById = (launchId: number) => {
 
 export const getLaunchFailedItems = (launchId: number, page = 1) => {
   const url = `${ENV.reportPortalApiUrl}/${ENV.reportPortalProject}/item`;
-  const query = `filter.eq.launchId=${launchId}&filter.eq.status=FAILED&page.size=100&filter.eq.type=STEP&page.page=${page}`;
+  const query = `filter.eq.launchId=${launchId}&filter.eq.status=FAILED&page.size=300&filter.eq.type=STEP&page.page=${page}`;
   return fetch(`${url}?${query}`, {
     method: "GET",
     headers,


### PR DESCRIPTION
Right now RPJ only checks the first page of the failed items for a RP launch, If there are more than 100 failures, a second page will be created and RPJ will ignore it.

This PR increases the page size to 300 and handles multi pages.